### PR TITLE
fix: Suppress intentional try-except-continue in tools catalog generator

### DIFF
--- a/tools/gen_tools_catalog.py
+++ b/tools/gen_tools_catalog.py
@@ -56,8 +56,8 @@ def iter_script_pages() -> list[dict[str, str]]:
                         "description": meta.get("description", ""),
                     }
                 )
-        except Exception:
-            # Skip files with parsing errors
+        except Exception:  # nosec B112
+            # Skip files with parsing errors (intentional)
             continue
 
     return script_pages


### PR DESCRIPTION
## Summary

Suppress Bandit B112 warning for intentional try-except-continue pattern in tools catalog generator.

## Changes

- Added `# nosec B112` comment to `tools/gen_tools_catalog.py:59`
- Updated comment to clarify intentional behavior
- The try-except-continue pattern is used to skip files with parsing errors when generating the tools catalog, which is safe for a documentation generation tool

## Testing

- ✅ All pre-commit hooks pass (including Bandit)
- ✅ 212 tests pass with 94.46% coverage
- ✅ No real security issues

## Related

Part of OpenSSF Best Practices Badge compliance preparation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)