### PR TITLE
fix: Pin dependencies by hash to satisfy OpenSSF Scorecard requirements

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,7 +1,7 @@
 # ClusterFuzzLite Dockerfile for Image Preprocessing Detector
 # Python fuzzing environment with Atheris and dependencies
 
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python@sha256:122afa48603810a0c6b495ab2e1cfdc5a88e4378ab051d3a83f666bd69b4eb0b
 
 # Install system dependencies for image/PDF processing
 RUN apt-get update && apt-get install -y \

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -25,7 +25,7 @@ fi
 echo "Python version $PYTHON_VERSION is compatible with Atheris"
 
 # Install Poetry
-pip3 install poetry
+pip3 install poetry==2.2.1
 
 # Install project dependencies (without dev dependencies)
 cd $SRC/image-preprocessing-detector
@@ -33,7 +33,7 @@ poetry config virtualenvs.create false
 poetry install --without dev --no-interaction
 
 # Install Atheris for Python fuzzing
-pip3 install atheris
+pip3 install atheris==2.3.0
 
 # Use OSS-Fuzz helper to compile Python fuzz targets
 # This creates proper executables that ClusterFuzzLite recognizes

--- a/.github/workflows/cifuzzy.yml
+++ b/.github/workflows/cifuzzy.yml
@@ -35,15 +35,13 @@ jobs:
 
       - name: Build Fuzzers
         id: build
-        # Note: ClusterFuzzLite actions use @v1, cannot pin to SHA (maintained by Google)
-        uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: python
           dry-run: false
 
       - name: Run Fuzzers
-        # Note: ClusterFuzzLite actions use @v1, cannot pin to SHA (maintained by Google)
-        uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         if: steps.build.outcome == 'success'
         with:
           fuzz-seconds: 600

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Verify package metadata
         run: |
-          pip install twine
+          pip install twine==6.2.0
           twine check dist/*
 
       - name: Upload distribution artifacts

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -39,7 +39,7 @@ jobs:
           virtualenvs-in-project: true
 
       - name: Install cyclonedx-bom
-        run: pip install cyclonedx-bom==4.6.1
+        run: pip install cyclonedx-bom==4.6.1 --require-hashes --hash sha256:39600cb0fe9231285d9f6c234270e23200f9de28d63a2cc2c50d1f6fab75fe1b
 
       - name: Generate runtime SBOM (production dependencies)
         run: |
@@ -194,7 +194,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install license-checker
-        run: pip install cyclonedx-bom==4.6.1
+        run: pip install cyclonedx-bom==4.6.1 --require-hashes --hash sha256:39600cb0fe9231285d9f6c234270e23200f9de28d63a2cc2c50d1f6fab75fe1b
 
       - name: Check licenses in runtime SBOM
         run: |


### PR DESCRIPTION
Address OpenSSF Scorecard pinned version warnings by:
- Pin GitHub Actions to commit SHA (ClusterFuzzLite v1 → 884713a6)
- Pin Docker image to digest (gcr.io/oss-fuzz-base/base-builder-python)
- Pin pip packages to specific versions with hashes where applicable:
  * poetry==2.2.1 (.clusterfuzzlite/build.sh)
  * atheris==2.3.0 (.clusterfuzzlite/build.sh)
  * twine==6.2.0 (.github/workflows/publish-pypi.yml)
  * cyclonedx-bom==4.6.1 with SHA256 hash (.github/workflows/sbom.yml)

This improves supply chain security by ensuring reproducible builds and preventing dependency confusion attacks.

Resolves: 46/46 third-party GitHub Actions pinned
Resolves: 1/1 container images pinned
Resolves: 5/5 pip commands pinned