### PR TITLE
fix(renovate): remove invalid matchSeverity field

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,169 +1,242 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    ":dependencyDashboard",
-    ":semanticCommits",
-    ":preserveSemverRanges"
-  ],
-  "timezone": "America/New_York",
-  "schedule": [
-    "after 10pm every weekday",
-    "before 5am every weekday",
-    "every weekend"
-  ],
-  "labels": [
-    "dependencies",
-    "automated"
-  ],
-  "assignees": [
-    "williaby"
-  ],
-  "reviewers": [
-    "williaby"
-  ],
-  "packageRules": [
-    {
-      "description": "Group Python dependencies by type",
-      "matchManagers": ["poetry"],
-      "matchDepTypes": ["dependencies"],
-      "groupName": "Python dependencies",
-      "automerge": false,
-      "schedule": ["every weekend"]
-    },
-    {
-      "description": "Group Python dev dependencies",
-      "matchManagers": ["poetry"],
-      "matchDepTypes": ["devDependencies"],
-      "groupName": "Python dev dependencies",
-      "automerge": false,
-      "schedule": ["every weekend"]
-    },
-    {
-      "description": "Auto-merge GitHub Actions minor/patch updates",
-      "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true,
-      "automergeType": "pr",
-      "automergeStrategy": "squash"
-    },
-    {
-      "description": "Group GitHub Actions updates",
-      "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions",
-      "commitMessageTopic": "GitHub Actions"
-    },
-    {
-      "description": "Security updates - high priority",
-      "matchDatasources": ["pypi", "github-actions"],
-      "vulnerabilityAlerts": {
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:recommended",
+        ":dependencyDashboard",
+        ":semanticCommits",
+        ":preserveSemverRanges"
+    ],
+    "timezone": "America/New_York",
+    "schedule": [
+        "after 10pm every weekday",
+        "before 5am every weekday",
+        "every weekend"
+    ],
+    "labels": [
+        "dependencies",
+        "automated"
+    ],
+    "assignees": [
+        "williaby"
+    ],
+    "reviewers": [
+        "williaby"
+    ],
+    "packageRules": [
+        {
+            "description": "Group Python dependencies by type",
+            "matchManagers": [
+                "poetry"
+            ],
+            "matchDepTypes": [
+                "dependencies"
+            ],
+            "groupName": "Python dependencies",
+            "automerge": false,
+            "schedule": [
+                "every weekend"
+            ]
+        },
+        {
+            "description": "Group Python dev dependencies",
+            "matchManagers": [
+                "poetry"
+            ],
+            "matchDepTypes": [
+                "devDependencies"
+            ],
+            "groupName": "Python dev dependencies",
+            "automerge": false,
+            "schedule": [
+                "every weekend"
+            ]
+        },
+        {
+            "description": "Auto-merge GitHub Actions minor/patch updates",
+            "matchManagers": [
+                "github-actions"
+            ],
+            "matchUpdateTypes": [
+                "minor",
+                "patch"
+            ],
+            "automerge": true,
+            "automergeType": "pr",
+            "automergeStrategy": "squash"
+        },
+        {
+            "description": "Group GitHub Actions updates",
+            "matchManagers": [
+                "github-actions"
+            ],
+            "groupName": "GitHub Actions",
+            "commitMessageTopic": "GitHub Actions"
+        },
+        {
+            "description": "Security updates - high priority",
+            "matchDatasources": [
+                "pypi",
+                "github-actions"
+            ],
+            "vulnerabilityAlerts": {
+                "enabled": true
+            },
+            "labels": [
+                "security",
+                "dependencies"
+            ],
+            "automerge": false,
+            "schedule": [
+                "at any time"
+            ]
+        },
+        {
+            "description": "Critical security updates - immediate",
+            "matchDatasources": [
+                "pypi"
+            ],
+            "matchCurrentVersion": "!/^0/",
+            "vulnerabilityAlerts": {
+                "enabled": true
+            },
+            "labels": [
+                "security",
+                "critical",
+                "dependencies"
+            ],
+            "automerge": false,
+            "prPriority": 10,
+            "schedule": [
+                "at any time"
+            ]
+        },
+        {
+            "description": "Pin GitHub Actions to commit SHA",
+            "matchManagers": [
+                "github-actions"
+            ],
+            "pinDigests": true
+        },
+        {
+            "description": "Image processing libraries - careful updates",
+            "matchPackageNames": [
+                "opencv-python",
+                "pillow",
+                "numpy",
+                "pymupdf"
+            ],
+            "automerge": false,
+            "labels": [
+                "dependencies",
+                "image-processing",
+                "needs-testing"
+            ],
+            "reviewersFromCodeOwners": true
+        },
+        {
+            "description": "ML libraries - Phase 2+ dependencies",
+            "matchPackageNames": [
+                "torch",
+                "torchvision",
+                "ultralytics",
+                "timm",
+                "albumentations",
+                "onnxruntime"
+            ],
+            "enabled": false,
+            "labels": [
+                "dependencies",
+                "ml",
+                "phase-2"
+            ]
+        },
+        {
+            "description": "Pydantic v2 - maintain major version",
+            "matchPackageNames": [
+                "pydantic",
+                "pydantic-settings"
+            ],
+            "matchUpdateTypes": [
+                "major"
+            ],
+            "enabled": false,
+            "labels": [
+                "dependencies",
+                "breaking-change"
+            ]
+        },
+        {
+            "description": "Python version updates - manual review required",
+            "matchDepTypes": [
+                "python"
+            ],
+            "enabled": false,
+            "labels": [
+                "dependencies",
+                "python-version",
+                "breaking-change"
+            ]
+        }
+    ],
+    "python": {
         "enabled": true
-      },
-      "labels": ["security", "dependencies"],
-      "automerge": false,
-      "schedule": ["at any time"]
     },
-    {
-      "description": "Critical security updates - immediate",
-      "matchDatasources": ["pypi"],
-      "matchCurrentVersion": "!/^0/",
-      "vulnerabilityAlerts": {
-        "enabled": true
-      },
-      "matchSeverity": ["CRITICAL", "HIGH"],
-      "labels": ["security", "critical", "dependencies"],
-      "automerge": false,
-      "prPriority": 10,
-      "schedule": ["at any time"]
+    "poetry": {
+        "enabled": true,
+        "fileMatch": [
+            "(^|/)pyproject\\.toml$"
+        ]
     },
-    {
-      "description": "Pin GitHub Actions to commit SHA",
-      "matchManagers": ["github-actions"],
-      "pinDigests": true
+    "lockFileMaintenance": {
+        "enabled": true,
+        "schedule": [
+            "before 5am on monday"
+        ],
+        "commitMessageAction": "Update",
+        "automerge": false,
+        "labels": [
+            "dependencies",
+            "lock-file-maintenance"
+        ]
     },
-    {
-      "description": "Image processing libraries - careful updates",
-      "matchPackageNames": [
-        "opencv-python",
-        "pillow",
-        "numpy",
-        "pymupdf"
-      ],
-      "automerge": false,
-      "labels": ["dependencies", "image-processing", "needs-testing"],
-      "reviewersFromCodeOwners": true
+    "separateMajorMinor": true,
+    "separateMinorPatch": false,
+    "prConcurrentLimit": 5,
+    "prHourlyLimit": 0,
+    "rebaseWhen": "conflicted",
+    "semanticCommits": "enabled",
+    "commitMessagePrefix": "chore(deps):",
+    "rangeStrategy": "bump",
+    "vulnerabilityAlerts": {
+        "enabled": true,
+        "labels": [
+            "security"
+        ],
+        "assignees": [
+            "williaby"
+        ],
+        "reviewers": [
+            "williaby"
+        ]
     },
-    {
-      "description": "ML libraries - Phase 2+ dependencies",
-      "matchPackageNames": [
-        "torch",
-        "torchvision",
-        "ultralytics",
-        "timm",
-        "albumentations",
-        "onnxruntime"
-      ],
-      "enabled": false,
-      "labels": ["dependencies", "ml", "phase-2"]
-    },
-    {
-      "description": "Pydantic v2 - maintain major version",
-      "matchPackageNames": ["pydantic", "pydantic-settings"],
-      "matchUpdateTypes": ["major"],
-      "enabled": false,
-      "labels": ["dependencies", "breaking-change"]
-    },
-    {
-      "description": "Python version updates - manual review required",
-      "matchDepTypes": ["python"],
-      "enabled": false,
-      "labels": ["dependencies", "python-version", "breaking-change"]
-    }
-  ],
-  "python": {
-    "enabled": true
-  },
-  "poetry": {
-    "enabled": true,
-    "fileMatch": ["(^|/)pyproject\\.toml$"]
-  },
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": ["before 5am on monday"],
-    "commitMessageAction": "Update",
-    "automerge": false,
-    "labels": ["dependencies", "lock-file-maintenance"]
-  },
-  "separateMajorMinor": true,
-  "separateMinorPatch": false,
-  "prConcurrentLimit": 5,
-  "prHourlyLimit": 0,
-  "rebaseWhen": "conflicted",
-  "semanticCommits": "enabled",
-  "commitMessagePrefix": "chore(deps):",
-  "rangeStrategy": "bump",
-  "vulnerabilityAlerts": {
-    "enabled": true,
-    "labels": ["security"],
-    "assignees": ["williaby"],
-    "reviewers": ["williaby"]
-  },
-  "osvVulnerabilityAlerts": true,
-  "transitiveRemediation": true,
-  "postUpdateOptions": [
-    "poetryMassage"
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "fileMatch": ["^\\.github/workflows/.*\\.ya?ml$"],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.*?_VERSION:\\s*[\"']?(?<currentValue>.*?)[\"']?\\s"
-      ]
-    }
-  ],
-  "enabledManagers": [
-    "poetry",
-    "github-actions"
-  ]
+    "osvVulnerabilityAlerts": true,
+    "transitiveRemediation": true,
+    "postUpdateOptions": [
+        "poetryMassage"
+    ],
+    "customManagers": [
+        {
+            "customType": "regex",
+            "fileMatch": [
+                "^\\.github/workflows/.*\\.ya?ml$"
+            ],
+            "matchStrings": [
+                "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.*?_VERSION:\\s*[\"']?(?<currentValue>.*?)[\"']?\\s"
+            ]
+        }
+    ],
+    "enabledManagers": [
+        "poetry",
+        "github-actions"
+    ]
 }


### PR DESCRIPTION
## Summary

Removes `matchSeverity` from `packageRules` -- this field was removed from Renovate's schema and causes config-validation errors that make Renovate skip all dependency checks for this repo.

## Why

`matchSeverity` is not a valid Renovate `packageRule` field. The global self-hosted Renovate config already handles CVE severity prioritization via `matchJsonata` rules.

## Changes

- `renovate.json`: removed `matchSeverity: ["CRITICAL", "HIGH"]` from the Critical security updates package rule

## Acceptance Criteria

- [ ] CI passes
- [ ] Next Renovate run shows `result=done` instead of `result=config-validation`

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration with formatting improvements. No impact on renewal behavior or scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->