### PR TITLE
chore(coderabbit): disable request_changes_workflow

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -27,7 +27,7 @@ reviews:
       - develop
 
   # Request changes workflow - makes reviews actionable
-  request_changes_workflow: true
+  request_changes_workflow: false
 
   # High-level summary - executive overview of changes
   high_level_summary: true


### PR DESCRIPTION
## Summary

CodeRabbit's `request_changes_workflow: true` was causing the bot to submit `CHANGES_REQUESTED` reviews on PRs with actionable comments. Under the org ruleset, any outstanding `CHANGES_REQUESTED` blocks merge even with `required_approving_review_count: 0`. The count only governs required approvals, not whether to ignore rejections.

Flipping to `false` (the CodeRabbit default) makes the bot submit `COMMENTED` reviews instead. Same review content, no merge gate.

## Related

Discovered debugging ByronWilliamsCPA/gleif#38 (BLOCKED with all green CI). Identical one-line PRs going out to all affected repos. Template fix in ByronWilliamsCPA/cookiecutter-python-template#52.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CodeRabbit review workflow configuration settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/williaby/image-preprocessing-detector/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->