### PR TITLE
docs(api): enrich FastAPI handlers, export OpenAPI, add Postman + Newman CI

### DIFF
--- a/.github/workflows/postman-api-tests.yml
+++ b/.github/workflows/postman-api-tests.yml
@@ -1,0 +1,154 @@
+# Postman / Newman API smoke tests against the FastAPI app.
+#
+# Required env vars (configured below; override via workflow inputs or repo
+# variables when needed):
+#   IMGPREP_API_AUTH_ENABLED  – disable auth for the test run (default: false)
+#   IMGPREP_API_RATE_LIMIT_ENABLED – disable rate limits for the test run
+#   IMGPREP_SKIP_MODEL_LOAD   – skip downloading / loading ML models on
+#                               startup. The FastAPI lifespan handler must
+#                               check this and avoid touching the model
+#                               registry when set to "true".
+#   PYTHONPATH                – `src` (so the in-tree package is importable)
+#
+# Required secrets:
+#   None for the default (auth-disabled) run. If you flip
+#   IMGPREP_API_AUTH_ENABLED=true, also provide:
+#     IMGPREP_API_API_KEYS – JSON list of accepted API keys, e.g.
+#                            ["test-key-1"]; the matching value is then
+#                            exported as POSTMAN_API_KEY for Newman.
+#
+# Local repro:
+#   uv sync --extra dev --extra api
+#   IMGPREP_SKIP_MODEL_LOAD=true uv run uvicorn \
+#       image_preprocessing_detector.api.app:app --port 8000 &
+#   curl --retry 30 --retry-delay 1 --retry-connrefused http://localhost:8000/health
+#   npx newman run docs/api/postman-collection.json \
+#       --env-var baseUrl=http://localhost:8000
+
+name: Postman API Tests
+
+on:
+  pull_request:
+    paths:
+      - "src/image_preprocessing_detector/api/**"
+      - "docs/api/openapi.json"
+      - "docs/api/postman-collection.json"
+      - "scripts/export_openapi.py"
+      - ".github/workflows/postman-api-tests.yml"
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  newman:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      PYTHONPATH: src
+      IMGPREP_API_AUTH_ENABLED: "false"
+      IMGPREP_API_RATE_LIMIT_ENABLED: "false"
+      IMGPREP_SKIP_MODEL_LOAD: "true"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: uv sync (api + dev extras)
+        run: uv sync --extra dev --extra api
+
+      - name: Set up Node.js for Newman
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Newman
+        run: npm install --global newman
+
+      - name: Generate test fixtures
+        run: |
+          mkdir -p tests/fixtures
+          uv run python - <<'PY'
+          from pathlib import Path
+          import numpy as np
+          from PIL import Image
+
+          fixtures = Path("tests/fixtures")
+          fixtures.mkdir(parents=True, exist_ok=True)
+
+          # Minimal valid PNG (white 64x64).
+          arr = np.full((64, 64, 3), 255, dtype="uint8")
+          Image.fromarray(arr).save(fixtures / "sample.png")
+
+          # Plain text file to exercise the invalid-file-type path.
+          (fixtures / "not-an-image.txt").write_text("not an image\n")
+          PY
+          ls -la tests/fixtures
+
+      - name: Start FastAPI app
+        run: |
+          uv run uvicorn image_preprocessing_detector.api.app:app \
+            --host 127.0.0.1 --port 8000 \
+            > uvicorn.log 2>&1 &
+          echo "UVICORN_PID=$!" >> "$GITHUB_ENV"
+
+      - name: Wait for /health to be ready
+        run: |
+          for i in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:8000/health > /dev/null; then
+              echo "API ready after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::API did not become ready within 60s"
+          cat uvicorn.log || true
+          exit 1
+
+      - name: Run Newman
+        run: |
+          newman run docs/api/postman-collection.json \
+            --env-var "baseUrl=http://127.0.0.1:8000" \
+            --env-var "apiKey=${POSTMAN_API_KEY:-}" \
+            --env-var "sampleImagePath=$(pwd)/tests/fixtures/sample.png" \
+            --working-dir "$(pwd)" \
+            --reporters cli,junit \
+            --reporter-junit-export newman-report.xml
+        env:
+          POSTMAN_API_KEY: ${{ secrets.IMGPREP_POSTMAN_API_KEY }}
+
+      - name: Upload Newman JUnit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: newman-report
+          path: newman-report.xml
+          if-no-files-found: warn
+
+      - name: Upload uvicorn logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: uvicorn-log
+          path: uvicorn.log
+          if-no-files-found: warn
+
+      - name: Stop FastAPI app
+        if: always()
+        run: |
+          if [ -n "${UVICORN_PID:-}" ]; then
+            kill "${UVICORN_PID}" || true
+          fi

--- a/.github/workflows/postman-api-tests.yml
+++ b/.github/workflows/postman-api-tests.yml
@@ -1,26 +1,24 @@
 # Postman / Newman API smoke tests against the FastAPI app.
 #
-# Required env vars (configured below; override via workflow inputs or repo
-# variables when needed):
-#   IMGPREP_API_AUTH_ENABLED  – disable auth for the test run (default: false)
-#   IMGPREP_API_RATE_LIMIT_ENABLED – disable rate limits for the test run
-#   IMGPREP_SKIP_MODEL_LOAD   – skip downloading / loading ML models on
-#                               startup. The FastAPI lifespan handler must
-#                               check this and avoid touching the model
-#                               registry when set to "true".
-#   PYTHONPATH                – `src` (so the in-tree package is importable)
+# Required env vars (configured in the job below):
+#   IMGPREP_API_AUTH_ENABLED        – disable auth for the test run (default: false)
+#   IMGPREP_API_RATE_LIMIT_ENABLED  – disable rate limits for the test run
+#   PYTHONPATH                      – `src` (so the in-tree package is importable)
+#
+# Model loading: the FastAPI lifespan already falls back gracefully when the
+# ONNX model files are absent (it logs `model_preload_failed` and continues),
+# so no explicit skip flag is required to run the smoke tests without models.
 #
 # Required secrets:
 #   None for the default (auth-disabled) run. If you flip
 #   IMGPREP_API_AUTH_ENABLED=true, also provide:
-#     IMGPREP_API_API_KEYS – JSON list of accepted API keys, e.g.
-#                            ["test-key-1"]; the matching value is then
-#                            exported as POSTMAN_API_KEY for Newman.
+#     IMGPREP_POSTMAN_API_KEY – an API key accepted by the running server;
+#                               passed to Newman as the `apiKey` collection
+#                               variable.
 #
 # Local repro:
 #   uv sync --extra dev --extra api
-#   IMGPREP_SKIP_MODEL_LOAD=true uv run uvicorn \
-#       image_preprocessing_detector.api.app:app --port 8000 &
+#   uv run uvicorn image_preprocessing_detector.api.app:app --port 8000 &
 #   curl --retry 30 --retry-delay 1 --retry-connrefused http://localhost:8000/health
 #   npx newman run docs/api/postman-collection.json \
 #       --env-var baseUrl=http://localhost:8000
@@ -51,7 +49,6 @@ jobs:
       PYTHONPATH: src
       IMGPREP_API_AUTH_ENABLED: "false"
       IMGPREP_API_RATE_LIMIT_ENABLED: "false"
-      IMGPREP_SKIP_MODEL_LOAD: "true"
 
     steps:
       - name: Checkout

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3,11 +3,9 @@
   "info": {
     "title": "Image Preprocessing Detector API",
     "description": "Front door for the RAG document pipeline. Accepts raw documents (PDF, PNG, JPEG, TIFF, WebP), assesses image quality, applies geometric and quality corrections, and returns structured `DocumentMetadata` plus OCR routing recommendations.\n\n## Features\n\n- **IQA pipeline**: 9 classical detectors + ResNet teacher/student ML IQA\n- **Document Quality Score (DQS)**: degradation + structural complexity\n- **PDF classification**: image_only / born_digital / hybrid\n- **Routing**: 4-strategy recommendation for downstream OCR\n- **Async batch**: submit-and-poll jobs for high-throughput ingestion\n\nSee [docs/api/rest-api.md](https://github.com/williaby/image-preprocessing-detector/blob/main/docs/api/rest-api.md) for detailed contracts and examples.",
-    "termsOfService": "https://github.com/williaby/image-preprocessing-detector/blob/main/LICENSE",
     "contact": {
       "name": "Image Preprocessing Detector Maintainers",
-      "url": "https://github.com/williaby/image-preprocessing-detector",
-      "email": "byron@example.com"
+      "url": "https://github.com/williaby/image-preprocessing-detector"
     },
     "license": {
       "name": "Apache-2.0",
@@ -19,10 +17,6 @@
     {
       "url": "http://localhost:8000",
       "description": "Local development server"
-    },
-    {
-      "url": "https://api.example.com",
-      "description": "Production server"
     }
   ],
   "paths": {

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1,0 +1,1285 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Image Preprocessing Detector API",
+    "description": "Front door for the RAG document pipeline. Accepts raw documents (PDF, PNG, JPEG, TIFF, WebP), assesses image quality, applies geometric and quality corrections, and returns structured `DocumentMetadata` plus OCR routing recommendations.\n\n## Features\n\n- **IQA pipeline**: 9 classical detectors + ResNet teacher/student ML IQA\n- **Document Quality Score (DQS)**: degradation + structural complexity\n- **PDF classification**: image_only / born_digital / hybrid\n- **Routing**: 4-strategy recommendation for downstream OCR\n- **Async batch**: submit-and-poll jobs for high-throughput ingestion\n\nSee [docs/api/rest-api.md](https://github.com/williaby/image-preprocessing-detector/blob/main/docs/api/rest-api.md) for detailed contracts and examples.",
+    "termsOfService": "https://github.com/williaby/image-preprocessing-detector/blob/main/LICENSE",
+    "contact": {
+      "name": "Image Preprocessing Detector Maintainers",
+      "url": "https://github.com/williaby/image-preprocessing-detector",
+      "email": "byron@example.com"
+    },
+    "license": {
+      "name": "Apache-2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    },
+    "version": "0.1.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8000",
+      "description": "Local development server"
+    },
+    {
+      "url": "https://api.example.com",
+      "description": "Production server"
+    }
+  ],
+  "paths": {
+    "/health": {
+      "get": {
+        "tags": [
+          "health"
+        ],
+        "summary": "Liveness check",
+        "description": "Basic liveness probe for load balancers and orchestrators. Returns `healthy` whenever the process is responding, along with a server timestamp and (if startup completed) uptime in seconds. Does not perform dependency checks \u2014 use `/ready` for that.",
+        "operationId": "health_check_health_get",
+        "responses": {
+          "200": {
+            "description": "Server is healthy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                },
+                "example": {
+                  "status": "healthy",
+                  "timestamp": "2025-01-15T10:30:00Z",
+                  "uptime_seconds": 3600.5
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Server is unhealthy"
+          }
+        }
+      }
+    },
+    "/ready": {
+      "get": {
+        "tags": [
+          "health"
+        ],
+        "summary": "Readiness check",
+        "description": "Readiness probe that validates dependencies required to serve requests:\n\n- Device capability probe (GPU/CPU detection)\n- Classical IQA detector imports\n- Pydantic schema imports\n- Configuration loading\n\nReturns HTTP 200 with `status=ready` when all checks pass, or HTTP 503 with `status=not_ready` and per-check details when any fail. Use this for Kubernetes readiness probes \u2014 failing readiness removes the pod from the service load balancer.",
+        "operationId": "readiness_check_ready_get",
+        "responses": {
+          "200": {
+            "description": "Server is ready to accept requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadyResponse"
+                },
+                "example": {
+                  "status": "ready",
+                  "timestamp": "2025-01-15T10:30:00Z",
+                  "checks": {
+                    "device_probe": true,
+                    "iqa_detectors": true,
+                    "schema": true,
+                    "configuration": true
+                  },
+                  "device": {
+                    "has_local_gpu": false,
+                    "cpu_count": 8,
+                    "modal_available": false
+                  }
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Server is not ready (one or more checks failed)"
+          }
+        }
+      }
+    },
+    "/version": {
+      "get": {
+        "tags": [
+          "health"
+        ],
+        "summary": "Version information",
+        "description": "Return the running API version, Python runtime version, processing pipeline version, and the resolved on-disk filenames for any currently-installed ONNX models (teacher / student / layout). Useful for diagnostics, support requests, and verifying model rollouts in production.",
+        "operationId": "version_info_version_get",
+        "responses": {
+          "200": {
+            "description": "Version metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VersionResponse"
+                },
+                "example": {
+                  "api_version": "0.1.0",
+                  "python_version": "3.11.6",
+                  "pipeline_version": "1.0.0",
+                  "models": {
+                    "teacher_model": "resnet50_teacher_50epoch",
+                    "student_model": "resnet18_student"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/process": {
+      "post": {
+        "tags": [
+          "process"
+        ],
+        "summary": "Process a single document",
+        "description": "Upload a single document (PDF or image) and run the full Project A preprocessing pipeline: ingestion, PDF type classification, classical IQA, optional ML IQA (teacher/student), correction decisions, DQS calculation, and OCR routing recommendation.\n\n**Supported extensions**: `.pdf`, `.png`, `.jpg`, `.jpeg`, `.tiff`, `.tif`, `.webp`.\n\n**Request shape**: `multipart/form-data` with a single `file` field. Pipeline behavior is tuned via query parameters (`prefer_gpu`, `enable_corrections`, `enable_teacher`).\n\n**Response shape**: a `ProcessResponse` envelope. On success `status=completed` and `result` is populated with the document summary (per-page IQA scores, DQS, routing). On validation or processing errors, the envelope carries `status=failed` and a structured `error` (see error codes in `/docs/api/rest-api.md`).",
+        "operationId": "process_single_document_process_post",
+        "parameters": [
+          {
+            "name": "prefer_gpu",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Whether to prefer GPU",
+              "default": true,
+              "title": "Prefer Gpu"
+            },
+            "description": "Whether to prefer GPU"
+          },
+          {
+            "name": "enable_corrections",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Whether to enable corrections",
+              "default": true,
+              "title": "Enable Corrections"
+            },
+            "description": "Whether to enable corrections"
+          },
+          {
+            "name": "enable_teacher",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Whether to enable teacher model",
+              "default": false,
+              "title": "Enable Teacher"
+            },
+            "description": "Whether to enable teacher model"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_process_single_document_process_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Document processed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessResponse"
+                },
+                "example": {
+                  "status": "completed",
+                  "result": {
+                    "document_id": "550e8400-e29b-41d4-a716-446655440000",
+                    "file_name": "document.pdf",
+                    "num_pages": 1,
+                    "pdf_type": "image_only",
+                    "dqs": {
+                      "degradation_score": 0.25,
+                      "structural_complexity_score": 0.3
+                    },
+                    "ocr_routing_recommendation": "ocr_fast",
+                    "pages": [
+                      {
+                        "page_index": 0,
+                        "width_px": 2550,
+                        "height_px": 3300,
+                        "issues_detected": 1,
+                        "corrections_applied": 0,
+                        "iqa_scores": {
+                          "blur_score": 0.85,
+                          "noise_score": 0.92,
+                          "contrast_score": 0.78
+                        }
+                      }
+                    ],
+                    "processing_time_ms": 1250.5,
+                    "device_used": "cpu"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error (invalid file type, oversized, empty filename).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing API key (auth enabled).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Invalid API key (auth enabled).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Processing failed (corrupt file, pipeline error).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/batch": {
+      "post": {
+        "tags": [
+          "batch"
+        ],
+        "summary": "Submit batch processing job",
+        "description": "Upload up to `IMGPREP_API_MAX_BATCH_SIZE` files (default 100) for asynchronous processing. Each file is validated up-front (extension allowlist, non-empty); if any fails validation the entire batch is rejected with HTTP 400 and no job is created. On success a job is enqueued via FastAPI background tasks and the response carries a `job_id` clients should poll on `/batch/{job_id}/status` until `status` reaches `completed` or `failed`.",
+        "operationId": "submit_batch_job_batch_post",
+        "parameters": [
+          {
+            "name": "prefer_gpu",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Whether to prefer GPU",
+              "default": true,
+              "title": "Prefer Gpu"
+            },
+            "description": "Whether to prefer GPU"
+          },
+          {
+            "name": "enable_corrections",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Whether to enable corrections",
+              "default": true,
+              "title": "Enable Corrections"
+            },
+            "description": "Whether to enable corrections"
+          },
+          {
+            "name": "enable_teacher",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Whether to enable teacher model",
+              "default": false,
+              "title": "Enable Teacher"
+            },
+            "description": "Whether to enable teacher model"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_submit_batch_job_batch_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Batch job submitted successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchJobStatus"
+                },
+                "example": {
+                  "job_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "status": "processing",
+                  "total_files": 4,
+                  "processed_files": 0,
+                  "failed_files": 0,
+                  "created_at": "2025-01-15T10:30:00Z",
+                  "updated_at": "2025-01-15T10:30:00Z"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid batch (size limit exceeded, no files, validation failure).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing API key (auth enabled).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Invalid API key (auth enabled).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/batch/{job_id}/status": {
+      "get": {
+        "tags": [
+          "batch"
+        ],
+        "summary": "Get batch job status",
+        "description": "Poll the current state of a batch job by `job_id`. Returns progress counters (`processed_files`, `failed_files`) and the overall `status` (`pending`, `processing`, `completed`, `failed`). When `status` reaches a terminal state (`completed` or `failed`), the `completed_at` timestamp is populated and full results can be fetched via `/batch/{job_id}/result`.",
+        "operationId": "get_batch_status_batch__job_id__status_get",
+        "parameters": [
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Job Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job status retrieved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchJobStatus"
+                },
+                "example": {
+                  "job_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "status": "processing",
+                  "total_files": 4,
+                  "processed_files": 2,
+                  "failed_files": 0,
+                  "created_at": "2025-01-15T10:30:00Z",
+                  "updated_at": "2025-01-15T10:32:00Z"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Job not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/batch/{job_id}/result": {
+      "get": {
+        "tags": [
+          "batch"
+        ],
+        "summary": "Get batch job results",
+        "description": "Fetch the results of a completed (or failed) batch job. Results are paginated via `offset` and `limit` query parameters. If the job is still running, returns HTTP 425 (Too Early) with the current progress so the client can back off and retry. Errors that occurred during individual file processing are returned in the `errors` array alongside the successful `results`.",
+        "operationId": "get_batch_result_batch__job_id__result_get",
+        "parameters": [
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Job Id"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job results retrieved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchJobResult"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Job not found"
+          },
+          "425": {
+            "description": "Job not yet completed; retry once status reaches a terminal state."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/batch/{job_id}": {
+      "delete": {
+        "tags": [
+          "batch"
+        ],
+        "summary": "Delete batch job",
+        "description": "Permanently remove a batch job and its stored results from the in-memory job store. Useful for explicit cleanup once a client has fetched and persisted the results downstream. The operation is idempotent for active jobs (returns 404 if `job_id` has already been removed).",
+        "operationId": "delete_batch_job_batch__job_id__delete",
+        "parameters": [
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Job Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Delete Batch Job Batch  Job Id  Delete"
+                },
+                "example": {
+                  "message": "Job 550e8400-e29b-41d4-a716-446655440000 deleted"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Job not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "BatchJobResult": {
+        "properties": {
+          "job_id": {
+            "type": "string",
+            "title": "Job Id",
+            "description": "Unique job identifier"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ProcessingStatus",
+            "description": "Job status"
+          },
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/ProcessingResult"
+            },
+            "type": "array",
+            "title": "Results",
+            "description": "Processing results"
+          },
+          "errors": {
+            "items": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            },
+            "type": "array",
+            "title": "Errors",
+            "description": "Processing errors"
+          },
+          "total_processing_time_ms": {
+            "type": "number",
+            "title": "Total Processing Time Ms",
+            "description": "Total processing time"
+          }
+        },
+        "type": "object",
+        "required": [
+          "job_id",
+          "status",
+          "total_processing_time_ms"
+        ],
+        "title": "BatchJobResult",
+        "description": "Result of a batch processing job."
+      },
+      "BatchJobStatus": {
+        "properties": {
+          "job_id": {
+            "type": "string",
+            "title": "Job Id",
+            "description": "Unique job identifier"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ProcessingStatus",
+            "description": "Job status"
+          },
+          "total_files": {
+            "type": "integer",
+            "title": "Total Files",
+            "description": "Total files in batch"
+          },
+          "processed_files": {
+            "type": "integer",
+            "title": "Processed Files",
+            "description": "Files processed so far",
+            "default": 0
+          },
+          "failed_files": {
+            "type": "integer",
+            "title": "Failed Files",
+            "description": "Files that failed processing",
+            "default": 0
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At",
+            "description": "Job creation timestamp"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At",
+            "description": "Last update timestamp"
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Completed At",
+            "description": "Completion timestamp"
+          },
+          "estimated_completion": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Estimated Completion",
+            "description": "Estimated completion time"
+          }
+        },
+        "type": "object",
+        "required": [
+          "job_id",
+          "status",
+          "total_files",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "BatchJobStatus",
+        "description": "Status of a batch processing job."
+      },
+      "Body_process_single_document_process_post": {
+        "properties": {
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File",
+            "description": "Document to process (PDF or image)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file"
+        ],
+        "title": "Body_process_single_document_process_post"
+      },
+      "Body_submit_batch_job_batch_post": {
+        "properties": {
+          "files": {
+            "items": {
+              "type": "string",
+              "format": "binary"
+            },
+            "type": "array",
+            "title": "Files",
+            "description": "Documents to process"
+          }
+        },
+        "type": "object",
+        "required": [
+          "files"
+        ],
+        "title": "Body_submit_batch_job_batch_post"
+      },
+      "DQSSummary": {
+        "properties": {
+          "degradation_score": {
+            "type": "number",
+            "title": "Degradation Score",
+            "description": "Overall degradation score (0-1)"
+          },
+          "structural_complexity_score": {
+            "type": "number",
+            "title": "Structural Complexity Score",
+            "description": "Structural complexity score (0-1)"
+          },
+          "pre_ocr_risk": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pre Ocr Risk",
+            "description": "Pre-OCR risk score (0-1)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "degradation_score",
+          "structural_complexity_score"
+        ],
+        "title": "DQSSummary",
+        "description": "Summary of Document Quality Score."
+      },
+      "ErrorCode": {
+        "type": "string",
+        "enum": [
+          "invalid_file_type",
+          "file_too_large",
+          "invalid_parameters",
+          "empty_file",
+          "processing_failed",
+          "corrupt_file",
+          "unsupported_format",
+          "internal_error",
+          "gpu_unavailable",
+          "model_load_failed",
+          "rate_limit_exceeded",
+          "unauthorized",
+          "forbidden"
+        ],
+        "title": "ErrorCode",
+        "description": "Structured error codes for API responses."
+      },
+      "ErrorResponse": {
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/ErrorCode",
+            "description": "Error code"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message",
+            "description": "Human-readable error message"
+          },
+          "details": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Details",
+            "description": "Additional error details"
+          },
+          "correlation_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Correlation Id",
+            "description": "Request correlation ID for debugging"
+          }
+        },
+        "type": "object",
+        "required": [
+          "error",
+          "message"
+        ],
+        "title": "ErrorResponse",
+        "description": "Standard error response model."
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "HealthResponse": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status",
+            "description": "Health status: healthy or unhealthy"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Timestamp",
+            "description": "Current server timestamp"
+          },
+          "uptime_seconds": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uptime Seconds",
+            "description": "Server uptime in seconds"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "timestamp"
+        ],
+        "title": "HealthResponse",
+        "description": "Response model for health check."
+      },
+      "IQAScoreSummary": {
+        "properties": {
+          "blur_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Blur Score",
+            "description": "Blur quality score"
+          },
+          "noise_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Noise Score",
+            "description": "Noise quality score"
+          },
+          "contrast_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Contrast Score",
+            "description": "Contrast quality score"
+          },
+          "skew_angle": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Skew Angle",
+            "description": "Detected skew angle"
+          }
+        },
+        "type": "object",
+        "title": "IQAScoreSummary",
+        "description": "Summary of IQA scores."
+      },
+      "PageSummary": {
+        "properties": {
+          "page_index": {
+            "type": "integer",
+            "title": "Page Index",
+            "description": "Page index (0-based)"
+          },
+          "width_px": {
+            "type": "integer",
+            "title": "Width Px",
+            "description": "Page width in pixels"
+          },
+          "height_px": {
+            "type": "integer",
+            "title": "Height Px",
+            "description": "Page height in pixels"
+          },
+          "issues_detected": {
+            "type": "integer",
+            "title": "Issues Detected",
+            "description": "Number of issues detected",
+            "default": 0
+          },
+          "corrections_applied": {
+            "type": "integer",
+            "title": "Corrections Applied",
+            "description": "Number of corrections applied",
+            "default": 0
+          },
+          "iqa_scores": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/IQAScoreSummary"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "IQA score summary"
+          }
+        },
+        "type": "object",
+        "required": [
+          "page_index",
+          "width_px",
+          "height_px"
+        ],
+        "title": "PageSummary",
+        "description": "Summary of a single page analysis."
+      },
+      "ProcessResponse": {
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/ProcessingStatus",
+            "description": "Processing status"
+          },
+          "result": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProcessingResult"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Processing result (if completed)"
+          },
+          "metadata_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata Url",
+            "description": "URL to full metadata JSON"
+          },
+          "corrected_images_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Corrected Images Url",
+            "description": "URL to corrected images"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ErrorResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Error details (if failed)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "title": "ProcessResponse",
+        "description": "Response for single document processing."
+      },
+      "ProcessingResult": {
+        "properties": {
+          "document_id": {
+            "type": "string",
+            "title": "Document Id",
+            "description": "Unique document identifier"
+          },
+          "file_name": {
+            "type": "string",
+            "title": "File Name",
+            "description": "Original file name"
+          },
+          "num_pages": {
+            "type": "integer",
+            "title": "Num Pages",
+            "description": "Number of pages processed"
+          },
+          "pdf_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pdf Type",
+            "description": "Detected PDF type (image_only, born_digital, hybrid)"
+          },
+          "dqs": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DQSSummary"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Document Quality Score"
+          },
+          "ocr_routing_recommendation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ocr Routing Recommendation",
+            "description": "Recommended OCR routing strategy"
+          },
+          "pages": {
+            "items": {
+              "$ref": "#/components/schemas/PageSummary"
+            },
+            "type": "array",
+            "title": "Pages",
+            "description": "Per-page summaries"
+          },
+          "processing_time_ms": {
+            "type": "number",
+            "title": "Processing Time Ms",
+            "description": "Total processing time in ms"
+          },
+          "device_used": {
+            "type": "string",
+            "title": "Device Used",
+            "description": "Device used for processing (cpu/gpu)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "document_id",
+          "file_name",
+          "num_pages",
+          "processing_time_ms",
+          "device_used"
+        ],
+        "title": "ProcessingResult",
+        "description": "Result of document processing."
+      },
+      "ProcessingStatus": {
+        "type": "string",
+        "enum": [
+          "pending",
+          "processing",
+          "completed",
+          "failed"
+        ],
+        "title": "ProcessingStatus",
+        "description": "Status of a processing job."
+      },
+      "ReadyResponse": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status",
+            "description": "Ready status: ready or not_ready"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Timestamp",
+            "description": "Current server timestamp"
+          },
+          "checks": {
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "type": "object",
+            "title": "Checks",
+            "description": "Individual readiness check results"
+          },
+          "device": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Device",
+            "description": "Available compute device information"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "timestamp",
+          "checks",
+          "device"
+        ],
+        "title": "ReadyResponse",
+        "description": "Response model for readiness check."
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "VersionResponse": {
+        "properties": {
+          "api_version": {
+            "type": "string",
+            "title": "Api Version",
+            "description": "API version string"
+          },
+          "python_version": {
+            "type": "string",
+            "title": "Python Version",
+            "description": "Python runtime version"
+          },
+          "pipeline_version": {
+            "type": "string",
+            "title": "Pipeline Version",
+            "description": "Processing pipeline version"
+          },
+          "models": {
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": "object",
+            "title": "Models",
+            "description": "Model version information"
+          }
+        },
+        "type": "object",
+        "required": [
+          "api_version",
+          "python_version",
+          "pipeline_version",
+          "models"
+        ],
+        "title": "VersionResponse",
+        "description": "Response model for version endpoint."
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "health",
+      "description": "Health and readiness endpoints"
+    },
+    {
+      "name": "process",
+      "description": "Document processing endpoints"
+    },
+    {
+      "name": "batch",
+      "description": "Batch processing endpoints"
+    }
+  ]
+}

--- a/docs/api/postman-collection.json
+++ b/docs/api/postman-collection.json
@@ -1,0 +1,397 @@
+{
+  "info": {
+    "name": "Image Preprocessing Detector API",
+    "description": "Postman collection for the Image Preprocessing Detector REST API. Variables:\n\n- `baseUrl` — root URL of the API (default: `http://localhost:8000`).\n- `apiKey` — value sent in the `X-API-Key` header (only required when `IMGPREP_API_AUTH_ENABLED=true`).\n- `sampleImagePath` — absolute path to a small test PDF or image on the machine running Newman/Postman. CI workflows generate one at runtime and override this variable.\n- `jobId` — captured automatically by the `Batch / Submit` request's test script.\n\nDerived from `docs/api/openapi.json`. Re-generate after API changes via `scripts/export_openapi.py` then keep this file in sync.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_postman_id": "ipd-api-collection-v1"
+  },
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:8000",
+      "type": "string"
+    },
+    {
+      "key": "apiKey",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "sampleImagePath",
+      "value": "./tests/fixtures/sample.png",
+      "type": "string"
+    },
+    {
+      "key": "jobId",
+      "value": "",
+      "type": "string"
+    }
+  ],
+  "auth": {
+    "type": "apikey",
+    "apikey": [
+      {"key": "key", "value": "X-API-Key", "type": "string"},
+      {"key": "value", "value": "{{apiKey}}", "type": "string"},
+      {"key": "in", "value": "header", "type": "string"}
+    ]
+  },
+  "item": [
+    {
+      "name": "Health",
+      "item": [
+        {
+          "name": "Health check",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/health",
+              "host": ["{{baseUrl}}"],
+              "path": ["health"]
+            },
+            "description": "Liveness probe. Returns 200 with `status=healthy`."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "pm.test('body has status=healthy', function () {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body).to.have.property('status', 'healthy');",
+                  "  pm.expect(body).to.have.property('timestamp');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Readiness check",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/ready",
+              "host": ["{{baseUrl}}"],
+              "path": ["ready"]
+            },
+            "description": "Readiness probe; 200 when all dependency checks pass, 503 otherwise."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200 or 503', function () {",
+                  "  pm.expect([200, 503]).to.include(pm.response.code);",
+                  "});",
+                  "pm.test('body has checks and device', function () {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body).to.have.property('status');",
+                  "  pm.expect(body).to.have.property('checks');",
+                  "  pm.expect(body).to.have.property('device');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Version info",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/version",
+              "host": ["{{baseUrl}}"],
+              "path": ["version"]
+            },
+            "description": "Returns API, Python, pipeline and detected model versions."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "pm.test('body has api_version and models', function () {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body).to.have.property('api_version');",
+                  "  pm.expect(body).to.have.property('python_version');",
+                  "  pm.expect(body).to.have.property('pipeline_version');",
+                  "  pm.expect(body).to.have.property('models');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Detection / Process",
+      "item": [
+        {
+          "name": "Process single document",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/process?prefer_gpu=true&enable_corrections=true&enable_teacher=false",
+              "host": ["{{baseUrl}}"],
+              "path": ["process"],
+              "query": [
+                {"key": "prefer_gpu", "value": "true"},
+                {"key": "enable_corrections", "value": "true"},
+                {"key": "enable_teacher", "value": "false"}
+              ]
+            },
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "file",
+                  "type": "file",
+                  "src": "{{sampleImagePath}}",
+                  "description": "PDF or image file (.pdf, .png, .jpg, .jpeg, .tiff, .tif, .webp)."
+                }
+              ]
+            },
+            "description": "Upload a PDF or image and run the IQA pipeline. Returns a `ProcessResponse` envelope with `status=completed` and per-page IQA + DQS + routing on success."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "pm.test('body has status=completed and result', function () {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body).to.have.property('status', 'completed');",
+                  "  pm.expect(body).to.have.property('result');",
+                  "  pm.expect(body.result).to.have.property('document_id');",
+                  "  pm.expect(body.result).to.have.property('num_pages');",
+                  "  pm.expect(body.result).to.have.property('pages');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Process — invalid file type (negative test)",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/process",
+              "host": ["{{baseUrl}}"],
+              "path": ["process"]
+            },
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "file",
+                  "type": "file",
+                  "src": "./tests/fixtures/not-an-image.txt",
+                  "description": "Path to a `.txt` file used to exercise the validation error path."
+                }
+              ]
+            },
+            "description": "Negative test: posting a non-image file should be rejected with HTTP 400 and `error=invalid_file_type`. Skip in Newman if the fixture is not present."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 400', function () {",
+                  "  pm.response.to.have.status(400);",
+                  "});",
+                  "pm.test('error code is invalid_file_type', function () {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body).to.have.property('status', 'failed');",
+                  "  pm.expect(body).to.have.property('error');",
+                  "  pm.expect(body.error).to.have.property('error', 'invalid_file_type');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Correction / Batch",
+      "description": "The batch endpoints orchestrate the same correction pipeline applied by `/process` over multiple files asynchronously.",
+      "item": [
+        {
+          "name": "Submit batch (correction pipeline)",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/batch?prefer_gpu=true&enable_corrections=true",
+              "host": ["{{baseUrl}}"],
+              "path": ["batch"],
+              "query": [
+                {"key": "prefer_gpu", "value": "true"},
+                {"key": "enable_corrections", "value": "true"}
+              ]
+            },
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "files",
+                  "type": "file",
+                  "src": "{{sampleImagePath}}",
+                  "description": "One or more files; corrections (deskew, CLAHE, sharpening, denoising) are applied per page when enabled."
+                }
+              ]
+            },
+            "description": "Submit an async batch job. Captures the returned `job_id` into the `jobId` collection variable for the polling requests below."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "pm.test('body has job_id and capture it', function () {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body).to.have.property('job_id');",
+                  "  pm.expect(body).to.have.property('status');",
+                  "  pm.expect(body).to.have.property('total_files');",
+                  "  pm.collectionVariables.set('jobId', body.job_id);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Batch status",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/batch/{{jobId}}/status",
+              "host": ["{{baseUrl}}"],
+              "path": ["batch", "{{jobId}}", "status"]
+            },
+            "description": "Poll progress for the `jobId` captured by the submit request."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "pm.test('body has progress counters', function () {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body).to.have.property('job_id');",
+                  "  pm.expect(body).to.have.property('status');",
+                  "  pm.expect(body).to.have.property('total_files');",
+                  "  pm.expect(body).to.have.property('processed_files');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Batch result",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/batch/{{jobId}}/result?offset=0&limit=100",
+              "host": ["{{baseUrl}}"],
+              "path": ["batch", "{{jobId}}", "result"],
+              "query": [
+                {"key": "offset", "value": "0"},
+                {"key": "limit", "value": "100"}
+              ]
+            },
+            "description": "Fetch paginated results. Returns 425 if the job is still running."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200, 404 or 425', function () {",
+                  "  pm.expect([200, 404, 425]).to.include(pm.response.code);",
+                  "});",
+                  "if (pm.response.code === 200) {",
+                  "  pm.test('body shape', function () {",
+                  "    const body = pm.response.json();",
+                  "    pm.expect(body).to.have.property('job_id');",
+                  "    pm.expect(body).to.have.property('status');",
+                  "    pm.expect(body).to.have.property('results');",
+                  "    pm.expect(body).to.have.property('errors');",
+                  "  });",
+                  "}"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Delete batch job",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/batch/{{jobId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["batch", "{{jobId}}"]
+            },
+            "description": "Tear down the batch job created above so the test run is self-cleaning."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200 or 404', function () {",
+                  "  pm.expect([200, 404]).to.include(pm.response.code);",
+                  "});",
+                  "if (pm.response.code === 200) {",
+                  "  pm.test('body has message', function () {",
+                  "    const body = pm.response.json();",
+                  "    pm.expect(body).to.have.property('message');",
+                  "  });",
+                  "}"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/api/postman-collection.json
+++ b/docs/api/postman-collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "Image Preprocessing Detector API",
-    "description": "Postman collection for the Image Preprocessing Detector REST API. Variables:\n\n- `baseUrl` — root URL of the API (default: `http://localhost:8000`).\n- `apiKey` — value sent in the `X-API-Key` header (only required when `IMGPREP_API_AUTH_ENABLED=true`).\n- `sampleImagePath` — absolute path to a small test PDF or image on the machine running Newman/Postman. CI workflows generate one at runtime and override this variable.\n- `jobId` — captured automatically by the `Batch / Submit` request's test script.\n\nDerived from `docs/api/openapi.json`. Re-generate after API changes via `scripts/export_openapi.py` then keep this file in sync.",
+    "description": "Postman collection for the Image Preprocessing Detector REST API. Variables:\n\n- `baseUrl` — root URL of the API (default: `http://localhost:8000`).\n- `apiKey` — value sent in the `X-API-Key` header on protected folders (Detection / Process and Correction / Batch). Required only when `IMGPREP_API_AUTH_ENABLED=true`; leave empty otherwise. Public health endpoints use `noauth` and never send the header.\n- `sampleImagePath` — absolute path to a small test PDF or image on the machine running Newman/Postman. CI workflows generate one at runtime and override this variable.\n- `jobId` — captured automatically by the `Batch / Submit` request's test script.\n\nDerived from `docs/api/openapi.json`. Re-generate after API changes via `scripts/export_openapi.py` then keep this file in sync.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "_postman_id": "ipd-api-collection-v1"
   },
@@ -28,16 +28,12 @@
     }
   ],
   "auth": {
-    "type": "apikey",
-    "apikey": [
-      {"key": "key", "value": "X-API-Key", "type": "string"},
-      {"key": "value", "value": "{{apiKey}}", "type": "string"},
-      {"key": "in", "value": "header", "type": "string"}
-    ]
+    "type": "noauth"
   },
   "item": [
     {
       "name": "Health",
+      "auth": {"type": "noauth"},
       "item": [
         {
           "name": "Health check",
@@ -139,6 +135,14 @@
     },
     {
       "name": "Detection / Process",
+      "auth": {
+        "type": "apikey",
+        "apikey": [
+          {"key": "key", "value": "X-API-Key", "type": "string"},
+          {"key": "value", "value": "{{apiKey}}", "type": "string"},
+          {"key": "in", "value": "header", "type": "string"}
+        ]
+      },
       "item": [
         {
           "name": "Process single document",
@@ -238,6 +242,14 @@
     {
       "name": "Correction / Batch",
       "description": "The batch endpoints orchestrate the same correction pipeline applied by `/process` over multiple files asynchronously.",
+      "auth": {
+        "type": "apikey",
+        "apikey": [
+          {"key": "key", "value": "X-API-Key", "type": "string"},
+          {"key": "value", "value": "{{apiKey}}", "type": "string"},
+          {"key": "in", "value": "header", "type": "string"}
+        ]
+      },
       "item": [
         {
           "name": "Submit batch (correction pipeline)",

--- a/scripts/export_openapi.py
+++ b/scripts/export_openapi.py
@@ -1,0 +1,66 @@
+"""Export the FastAPI OpenAPI schema to docs/api/openapi.json.
+
+Run from the repository root:
+
+    uv run python scripts/export_openapi.py [--output PATH]
+
+The script imports the FastAPI app, calls ``app.openapi()``, and writes the
+returned schema as pretty-printed JSON. The companion Markdown reference
+files under ``docs/api/`` are not touched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_OUTPUT = REPO_ROOT / "docs" / "api" / "openapi.json"
+
+
+def _ensure_src_on_path() -> None:
+    src_dir = REPO_ROOT / "src"
+    if src_dir.exists() and str(src_dir) not in sys.path:
+        sys.path.insert(0, str(src_dir))
+
+
+def export_openapi(output_path: Path) -> Path:
+    """Generate the OpenAPI spec and write it to ``output_path``.
+
+    Returns the resolved output path for convenience.
+    """
+    _ensure_src_on_path()
+
+    # Imported lazily so ``sys.path`` is configured first.
+    from image_preprocessing_detector.api.app import create_app
+
+    app = create_app()
+    schema = app.openapi()
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(schema, indent=2, sort_keys=False) + "\n",
+        encoding="utf-8",
+    )
+    return output_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help=f"Output path for the OpenAPI JSON (default: {DEFAULT_OUTPUT}).",
+    )
+    args = parser.parse_args(argv)
+
+    written = export_openapi(args.output)
+    print(f"Wrote OpenAPI schema to {written}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/image_preprocessing_detector/api/app.py
+++ b/src/image_preprocessing_detector/api/app.py
@@ -156,6 +156,20 @@ def create_app(settings: APISettings | None = None) -> FastAPI:
         docs_url="/docs",
         redoc_url="/redoc",
         openapi_url="/openapi.json",
+        terms_of_service=settings.terms_of_service,
+        contact={
+            "name": settings.contact_name,
+            "url": settings.contact_url,
+            "email": settings.contact_email,
+        },
+        license_info={
+            "name": settings.license_name,
+            "url": settings.license_url,
+        },
+        servers=[
+            {"url": "http://localhost:8000", "description": "Local development server"},
+            {"url": "https://api.example.com", "description": "Production server"},
+        ],
     )
 
     # Add request logging middleware

--- a/src/image_preprocessing_detector/api/app.py
+++ b/src/image_preprocessing_detector/api/app.py
@@ -147,30 +147,37 @@ def create_app(settings: APISettings | None = None) -> FastAPI:
     if settings is None:
         settings = get_api_settings()
 
-    app = FastAPI(
-        title=settings.title,
-        description=settings.description,
-        version=settings.version,
-        lifespan=lifespan,
-        openapi_tags=settings.get_openapi_tags(),
-        docs_url="/docs",
-        redoc_url="/redoc",
-        openapi_url="/openapi.json",
-        terms_of_service=settings.terms_of_service,
-        contact={
-            "name": settings.contact_name,
-            "url": settings.contact_url,
-            "email": settings.contact_email,
-        },
-        license_info={
+    contact: dict[str, str] = {}
+    if settings.contact_name:
+        contact["name"] = settings.contact_name
+    if settings.contact_url:
+        contact["url"] = settings.contact_url
+    if settings.contact_email:
+        contact["email"] = settings.contact_email
+
+    fastapi_kwargs: dict[str, Any] = {
+        "title": settings.title,
+        "description": settings.description,
+        "version": settings.version,
+        "lifespan": lifespan,
+        "openapi_tags": settings.get_openapi_tags(),
+        "docs_url": "/docs",
+        "redoc_url": "/redoc",
+        "openapi_url": "/openapi.json",
+        "license_info": {
             "name": settings.license_name,
             "url": settings.license_url,
         },
-        servers=[
+        "servers": [
             {"url": "http://localhost:8000", "description": "Local development server"},
-            {"url": "https://api.example.com", "description": "Production server"},
         ],
-    )
+    }
+    if contact:
+        fastapi_kwargs["contact"] = contact
+    if settings.terms_of_service:
+        fastapi_kwargs["terms_of_service"] = settings.terms_of_service
+
+    app = FastAPI(**fastapi_kwargs)
 
     # Add request logging middleware
     app.add_middleware(

--- a/src/image_preprocessing_detector/api/config.py
+++ b/src/image_preprocessing_detector/api/config.py
@@ -59,8 +59,11 @@ class APISettings(BaseSettings):
         description="OpenAPI contact URL",
     )
     contact_email: str = Field(
-        default="byron@example.com",
-        description="OpenAPI contact email",
+        default="",
+        description=(
+            "OpenAPI contact email. Leave empty to omit `email` from the "
+            "published `info.contact` object — preferred over a placeholder."
+        ),
     )
     license_name: str = Field(
         default="Apache-2.0",
@@ -71,8 +74,12 @@ class APISettings(BaseSettings):
         description="OpenAPI license URL",
     )
     terms_of_service: str = Field(
-        default="https://github.com/williaby/image-preprocessing-detector/blob/main/LICENSE",
-        description="OpenAPI terms of service URL",
+        default="",
+        description=(
+            "OpenAPI terms-of-service URL. Leave empty to omit "
+            "`info.termsOfService` from the published schema; do not point "
+            "this at the project LICENSE."
+        ),
     )
 
     # CORS settings

--- a/src/image_preprocessing_detector/api/config.py
+++ b/src/image_preprocessing_detector/api/config.py
@@ -30,12 +30,49 @@ class APISettings(BaseSettings):
         description="API title for OpenAPI docs",
     )
     description: str = Field(
-        default="Intelligent image preprocessing detection for RAG document pipelines",
+        default=(
+            "Front door for the RAG document pipeline. Accepts raw documents "
+            "(PDF, PNG, JPEG, TIFF, WebP), assesses image quality, applies "
+            "geometric and quality corrections, and returns structured "
+            "`DocumentMetadata` plus OCR routing recommendations.\n\n"
+            "## Features\n\n"
+            "- **IQA pipeline**: 9 classical detectors + ResNet teacher/student ML IQA\n"
+            "- **Document Quality Score (DQS)**: degradation + structural complexity\n"
+            "- **PDF classification**: image_only / born_digital / hybrid\n"
+            "- **Routing**: 4-strategy recommendation for downstream OCR\n"
+            "- **Async batch**: submit-and-poll jobs for high-throughput ingestion\n\n"
+            "See [docs/api/rest-api.md](https://github.com/williaby/image-preprocessing-detector/"
+            "blob/main/docs/api/rest-api.md) for detailed contracts and examples."
+        ),
         description="API description for OpenAPI docs",
     )
     version: str = Field(
         default="0.1.0",
         description="API version",
+    )
+    contact_name: str = Field(
+        default="Image Preprocessing Detector Maintainers",
+        description="OpenAPI contact name",
+    )
+    contact_url: str = Field(
+        default="https://github.com/williaby/image-preprocessing-detector",
+        description="OpenAPI contact URL",
+    )
+    contact_email: str = Field(
+        default="byron@example.com",
+        description="OpenAPI contact email",
+    )
+    license_name: str = Field(
+        default="Apache-2.0",
+        description="OpenAPI license name",
+    )
+    license_url: str = Field(
+        default="https://www.apache.org/licenses/LICENSE-2.0",
+        description="OpenAPI license URL",
+    )
+    terms_of_service: str = Field(
+        default="https://github.com/williaby/image-preprocessing-detector/blob/main/LICENSE",
+        description="OpenAPI terms of service URL",
     )
 
     # CORS settings

--- a/src/image_preprocessing_detector/api/routes/batch.py
+++ b/src/image_preprocessing_detector/api/routes/batch.py
@@ -175,11 +175,44 @@ async def process_batch_job(
 @router.post(
     "",
     response_model=BatchJobStatus,
+    status_code=status.HTTP_200_OK,
     summary="Submit batch processing job",
-    description="Upload multiple files for batch processing. Returns a job ID for tracking.",
+    description=(
+        "Upload up to `IMGPREP_API_MAX_BATCH_SIZE` files (default 100) for "
+        "asynchronous processing. Each file is validated up-front (extension "
+        "allowlist, non-empty); if any fails validation the entire batch is "
+        "rejected with HTTP 400 and no job is created. On success a job is "
+        "enqueued via FastAPI background tasks and the response carries a "
+        "`job_id` clients should poll on `/batch/{job_id}/status` until "
+        "`status` reaches `completed` or `failed`."
+    ),
+    response_description="Initial batch job state with `job_id` for polling.",
     responses={
-        200: {"description": "Batch job submitted successfully"},
-        400: {"description": "Invalid request"},
+        200: {
+            "description": "Batch job submitted successfully",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "job_id": "550e8400-e29b-41d4-a716-446655440000",
+                        "status": "processing",
+                        "total_files": 4,
+                        "processed_files": 0,
+                        "failed_files": 0,
+                        "created_at": "2025-01-15T10:30:00Z",
+                        "updated_at": "2025-01-15T10:30:00Z",
+                        "completed_at": None,
+                        "estimated_completion": None,
+                    }
+                }
+            },
+        },
+        400: {
+            "model": ErrorResponse,
+            "description": "Invalid batch (size limit exceeded, no files, validation failure).",
+        },
+        401: {"model": ErrorResponse, "description": "Missing API key (auth enabled)."},
+        403: {"model": ErrorResponse, "description": "Invalid API key (auth enabled)."},
+        429: {"model": ErrorResponse, "description": "Rate limit exceeded."},
     },
 )
 async def submit_batch_job(
@@ -308,21 +341,55 @@ async def submit_batch_job(
 
 @router.get(
     "/{job_id}/status",
+    response_model=BatchJobStatus,
+    status_code=status.HTTP_200_OK,
     summary="Get batch job status",
-    description="Get the current status of a batch processing job.",
+    description=(
+        "Poll the current state of a batch job by `job_id`. Returns progress "
+        "counters (`processed_files`, `failed_files`) and the overall "
+        "`status` (`pending`, `processing`, `completed`, `failed`). When "
+        "`status` reaches a terminal state (`completed` or `failed`), the "
+        "`completed_at` timestamp is populated and full results can be "
+        "fetched via `/batch/{job_id}/result`."
+    ),
+    response_description="Latest known job progress and lifecycle timestamps.",
     responses={
-        200: {"description": "Job status retrieved"},
+        200: {
+            "description": "Job status retrieved",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "job_id": "550e8400-e29b-41d4-a716-446655440000",
+                        "status": "processing",
+                        "total_files": 4,
+                        "processed_files": 2,
+                        "failed_files": 0,
+                        "created_at": "2025-01-15T10:30:00Z",
+                        "updated_at": "2025-01-15T10:32:00Z",
+                        "completed_at": None,
+                        "estimated_completion": None,
+                    }
+                }
+            },
+        },
         404: {"description": "Job not found"},
     },
 )
 async def get_batch_status(job_id: str) -> BatchJobStatus:
-    """Get the status of a batch job.
+    """Return the current lifecycle state of a batch job.
+
+    Looks up the in-memory job store; jobs older than ~24h may have been
+    reclaimed. Used by clients to poll progress between submission and
+    result retrieval.
 
     Args:
-        job_id: The job ID.
+        job_id: UUID returned by `POST /batch`.
 
     Returns:
-        BatchJobStatus with current progress.
+        BatchJobStatus snapshot of progress counters and timestamps.
+
+    Raises:
+        HTTPException: 404 when `job_id` is unknown or has expired.
     """
     job = _get_job(job_id)
     if not job:
@@ -346,12 +413,23 @@ async def get_batch_status(job_id: str) -> BatchJobStatus:
 @router.get(
     "/{job_id}/result",
     response_model=BatchJobResult,
+    status_code=status.HTTP_200_OK,
     summary="Get batch job results",
-    description="Get the results of a completed batch processing job.",
+    description=(
+        "Fetch the results of a completed (or failed) batch job. Results are "
+        "paginated via `offset` and `limit` query parameters. If the job is "
+        "still running, returns HTTP 425 (Too Early) with the current "
+        "progress so the client can back off and retry. Errors that "
+        "occurred during individual file processing are returned in the "
+        "`errors` array alongside the successful `results`."
+    ),
+    response_description="Paginated processing results plus any per-file errors.",
     responses={
         200: {"description": "Job results retrieved"},
         404: {"description": "Job not found"},
-        425: {"description": "Job not yet completed"},
+        425: {
+            "description": "Job not yet completed; retry once status reaches a terminal state."
+        },
     },
 )
 async def get_batch_result(
@@ -359,15 +437,19 @@ async def get_batch_result(
     offset: int = 0,
     limit: int = 100,
 ) -> BatchJobResult | JSONResponse:
-    """Get the results of a batch job.
+    """Return the (possibly paginated) results of a batch job.
 
     Args:
-        job_id: The job ID.
-        offset: Pagination offset.
-        limit: Maximum results to return.
+        job_id: UUID returned by `POST /batch`.
+        offset: Zero-based index of the first result to return.
+        limit: Maximum number of results in the response page.
 
     Returns:
-        BatchJobResult with processing results.
+        BatchJobResult (HTTP 200) when the job has reached a terminal state,
+        otherwise a JSONResponse with HTTP 425 carrying the current progress.
+
+    Raises:
+        HTTPException: 404 when `job_id` is unknown.
     """
     job = _get_job(job_id)
     if not job:
@@ -401,21 +483,41 @@ async def get_batch_result(
 
 @router.delete(
     "/{job_id}",
+    status_code=status.HTTP_200_OK,
     summary="Delete batch job",
-    description="Delete a batch job and its results.",
+    description=(
+        "Permanently remove a batch job and its stored results from the "
+        "in-memory job store. Useful for explicit cleanup once a client has "
+        "fetched and persisted the results downstream. The operation is "
+        "idempotent for active jobs (returns 404 if `job_id` has already "
+        "been removed)."
+    ),
+    response_description="Single-field confirmation message.",
     responses={
-        200: {"description": "Job deleted"},
+        200: {
+            "description": "Job deleted",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "message": "Job 550e8400-e29b-41d4-a716-446655440000 deleted"
+                    }
+                }
+            },
+        },
         404: {"description": "Job not found"},
     },
 )
 async def delete_batch_job(job_id: str) -> dict[str, str]:
-    """Delete a batch job.
+    """Delete a batch job from the in-memory store.
 
     Args:
-        job_id: The job ID.
+        job_id: UUID returned by `POST /batch`.
 
     Returns:
-        Confirmation message.
+        Single-key dict with a human-readable confirmation `message`.
+
+    Raises:
+        HTTPException: 404 when `job_id` is unknown.
     """
     if job_id not in _job_store:
         raise HTTPException(

--- a/src/image_preprocessing_detector/api/routes/health.py
+++ b/src/image_preprocessing_detector/api/routes/health.py
@@ -73,18 +73,43 @@ def get_uptime_seconds() -> float | None:
 
 @router.get(
     "/health",
-    summary="Health check",
-    description="Basic liveness check - returns healthy if server is running.",
+    response_model=HealthResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Liveness check",
+    description=(
+        "Basic liveness probe for load balancers and orchestrators. "
+        "Returns `healthy` whenever the process is responding, along with a "
+        "server timestamp and (if startup completed) uptime in seconds. Does "
+        "not perform dependency checks — use `/ready` for that."
+    ),
+    response_description="Server is alive; returns liveness status, timestamp, and uptime.",
     responses={
-        200: {"description": "Server is healthy"},
+        200: {
+            "description": "Server is healthy",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "status": "healthy",
+                        "timestamp": "2025-01-15T10:30:00Z",
+                        "uptime_seconds": 3600.5,
+                    }
+                }
+            },
+        },
         503: {"description": "Server is unhealthy"},
     },
 )
 async def health_check() -> HealthResponse:
-    """Check if the server is alive and responding.
+    """Return liveness status of the API process.
+
+    Used by container orchestrators (Kubernetes, Docker Swarm) and load
+    balancers as a cheap liveness probe. Does NOT validate that downstream
+    dependencies (models, GPU, configuration) are available; that is the
+    responsibility of `/ready`.
 
     Returns:
-        HealthResponse with status and timestamp.
+        HealthResponse with status (`healthy`), current UTC timestamp, and
+        uptime in seconds since application startup.
     """
     logger.debug("health_check_called")
     return HealthResponse(
@@ -96,11 +121,47 @@ async def health_check() -> HealthResponse:
 
 @router.get(
     "/ready",
+    response_model=ReadyResponse,
+    status_code=status.HTTP_200_OK,
     summary="Readiness check",
-    description="Readiness check with dependency validation for load balancer probes.",
+    description=(
+        "Readiness probe that validates dependencies required to serve "
+        "requests:\n\n"
+        "- Device capability probe (GPU/CPU detection)\n"
+        "- Classical IQA detector imports\n"
+        "- Pydantic schema imports\n"
+        "- Configuration loading\n\n"
+        "Returns HTTP 200 with `status=ready` when all checks pass, or HTTP "
+        "503 with `status=not_ready` and per-check details when any fail. "
+        "Use this for Kubernetes readiness probes — failing readiness "
+        "removes the pod from the service load balancer."
+    ),
+    response_description="Per-component readiness checks and detected device information.",
     responses={
-        200: {"description": "Server is ready to accept requests"},
-        503: {"description": "Server is not ready"},
+        200: {
+            "description": "Server is ready to accept requests",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "status": "ready",
+                        "timestamp": "2025-01-15T10:30:00Z",
+                        "checks": {
+                            "device_probe": True,
+                            "iqa_detectors": True,
+                            "schema": True,
+                            "configuration": True,
+                        },
+                        "device": {
+                            "has_local_gpu": False,
+                            "gpu_name": None,
+                            "cpu_count": 8,
+                            "modal_available": False,
+                        },
+                    }
+                }
+            },
+        },
+        503: {"description": "Server is not ready (one or more checks failed)"},
     },
 )
 async def readiness_check(response: Response) -> ReadyResponse:
@@ -185,8 +246,36 @@ async def readiness_check(response: Response) -> ReadyResponse:
 
 @router.get(
     "/version",
+    response_model=VersionResponse,
+    status_code=status.HTTP_200_OK,
     summary="Version information",
-    description="Returns API version, Python version, and model versions.",
+    description=(
+        "Return the running API version, Python runtime version, processing "
+        "pipeline version, and the resolved on-disk filenames for any "
+        "currently-installed ONNX models (teacher / student / layout). "
+        "Useful for diagnostics, support requests, and verifying model "
+        "rollouts in production."
+    ),
+    response_description="Version metadata for API, runtime, pipeline, and ML models.",
+    responses={
+        200: {
+            "description": "Version metadata",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "api_version": "0.1.0",
+                        "python_version": "3.11.6",
+                        "pipeline_version": "1.0.0",
+                        "models": {
+                            "teacher_model": "resnet50_teacher_50epoch",
+                            "student_model": "resnet18_student",
+                            "layout_model": None,
+                        },
+                    }
+                }
+            },
+        },
+    },
 )
 async def version_info() -> VersionResponse:
     """Get version information for the API and models.

--- a/src/image_preprocessing_detector/api/routes/process.py
+++ b/src/image_preprocessing_detector/api/routes/process.py
@@ -254,13 +254,80 @@ async def process_document(  # nosonar  # async required: callers use await
 @router.post(
     "",
     response_model=ProcessResponse,
+    status_code=status.HTTP_200_OK,
     summary="Process a single document",
-    description="Upload and process a single PDF or image file for IQA analysis.",
+    description=(
+        "Upload a single document (PDF or image) and run the full Project A "
+        "preprocessing pipeline: ingestion, PDF type classification, "
+        "classical IQA, optional ML IQA (teacher/student), correction "
+        "decisions, DQS calculation, and OCR routing recommendation.\n\n"
+        "**Supported extensions**: `.pdf`, `.png`, `.jpg`, `.jpeg`, `.tiff`, "
+        "`.tif`, `.webp`.\n\n"
+        "**Request shape**: `multipart/form-data` with a single `file` field. "
+        "Pipeline behavior is tuned via query parameters "
+        "(`prefer_gpu`, `enable_corrections`, `enable_teacher`).\n\n"
+        "**Response shape**: a `ProcessResponse` envelope. On success "
+        "`status=completed` and `result` is populated with the document "
+        "summary (per-page IQA scores, DQS, routing). On validation or "
+        "processing errors, the envelope carries `status=failed` and a "
+        "structured `error` (see error codes in `/docs/api/rest-api.md`)."
+    ),
+    response_description="Processing envelope with per-page IQA summary, DQS, and OCR routing recommendation.",
     responses={
-        200: {"description": "Document processed successfully"},
-        400: {"description": "Invalid request (file type, size, etc.)"},
-        422: {"description": "Processing failed"},
-        500: {"description": "Internal server error"},
+        200: {
+            "description": "Document processed successfully",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "status": "completed",
+                        "result": {
+                            "document_id": "550e8400-e29b-41d4-a716-446655440000",
+                            "file_name": "document.pdf",
+                            "num_pages": 1,
+                            "pdf_type": "image_only",
+                            "dqs": {
+                                "degradation_score": 0.25,
+                                "structural_complexity_score": 0.3,
+                                "pre_ocr_risk": None,
+                            },
+                            "ocr_routing_recommendation": "ocr_fast",
+                            "pages": [
+                                {
+                                    "page_index": 0,
+                                    "width_px": 2550,
+                                    "height_px": 3300,
+                                    "issues_detected": 1,
+                                    "corrections_applied": 0,
+                                    "iqa_scores": {
+                                        "blur_score": 0.85,
+                                        "noise_score": 0.92,
+                                        "contrast_score": 0.78,
+                                        "skew_angle": None,
+                                    },
+                                }
+                            ],
+                            "processing_time_ms": 1250.5,
+                            "device_used": "cpu",
+                        },
+                        "metadata_url": None,
+                        "corrected_images_url": None,
+                        "error": None,
+                    }
+                }
+            },
+        },
+        400: {
+            "model": ProcessResponse,
+            "description": "Validation error (invalid file type, oversized, empty filename).",
+        },
+        401: {"model": ErrorResponse, "description": "Missing API key (auth enabled)."},
+        403: {"model": ErrorResponse, "description": "Invalid API key (auth enabled)."},
+        422: {
+            "model": ProcessResponse,
+            "description": "Processing failed (corrupt file, pipeline error).",
+        },
+        429: {"model": ErrorResponse, "description": "Rate limit exceeded."},
+        500: {"model": ErrorResponse, "description": "Internal server error."},
     },
 )
 async def process_single_document(
@@ -273,16 +340,28 @@ async def process_single_document(
         bool, Query(description="Whether to enable teacher model")
     ] = False,
 ) -> ProcessResponse | JSONResponse:
-    """Process a single document.
+    """Run the full preprocessing pipeline on a single uploaded document.
+
+    The handler validates the upload (extension allowlist, max size, non-empty),
+    persists it to a temp file, then invokes :func:`process_document` which
+    performs ingestion, classical IQA, DQS scoring, and OCR routing
+    recommendation. Temp files are cleaned up in the `finally` block.
 
     Args:
-        file: The uploaded document file.
-        prefer_gpu: Whether to prefer GPU for processing.
-        enable_corrections: Whether to apply automatic corrections.
-        enable_teacher: Whether to enable teacher model inference.
+        file: Uploaded document (PDF / PNG / JPEG / TIFF / WebP).
+        prefer_gpu: When true, prefer a local CUDA device for ML inference;
+            falls back to CPU if no GPU is available.
+        enable_corrections: When true, allow the pipeline to apply geometric
+            and quality corrections (deskew, CLAHE, sharpening, denoising)
+            after IQA assessment.
+        enable_teacher: When true, run the higher-capacity ResNet-50 teacher
+            model in addition to the student. The teacher is otherwise
+            invoked only on uncertain or high-risk pages.
 
     Returns:
-        ProcessResponse with processing results.
+        ``ProcessResponse`` (HTTP 200) on success, or ``JSONResponse``
+        carrying a ``ProcessResponse`` envelope with HTTP 400 (validation)
+        or 422 (processing failure).
     """
     settings = get_api_settings()
     correlation_id = get_correlation_id()


### PR DESCRIPTION
## Summary

Three coordinated deliverables for the FastAPI surface:

1. Reconciled every route handler in `src/image_preprocessing_detector/api/routes/` with the contracts already documented in `docs/api/rest-api.md`.
2. Enriched the `FastAPI()` constructor (title, description, version, contact, license, terms of service, servers) via `APISettings`.
3. Generated `docs/api/openapi.json` (via `scripts/export_openapi.py`) and a Postman v2.1 `docs/api/postman-collection.json`, plus a `.github/workflows/postman-api-tests.yml` job that runs Newman on PRs and pushes to `main`.

Local Newman run against the live app passes **18/18 assertions across 9 requests**.

## (1) Routes enriched

For each route the change adds (at minimum) `response_model=`, `status_code=`, an expanded `summary`, multi-paragraph `description`, full `responses={…}` map with `model=` entries pointing at real Pydantic models, and a deeper Google-style docstring on the handler.

| Method | Path | Notes |
|---|---|---|
| GET | `/health` | Liveness probe; documented 200/503 with response example. |
| GET | `/ready` | Readiness probe; documents the actual checks (`device_probe`, `iqa_detectors`, `schema`, `configuration`) and `device` payload returned by the code. |
| GET | `/version` | Pipeline + runtime + ONNX model filenames as actually returned. |
| POST | `/process` | Full positive-path example, complete error matrix (400/401/403/422/429/500), `ProcessResponse` typed for validation/processing-failure shapes. |
| POST | `/batch` | Submit job; documents the up-front validation rule (any bad file rejects the whole batch). |
| GET | `/batch/{job_id}/status` | Polling contract + terminal-state semantics. |
| GET | `/batch/{job_id}/result` | Pagination (`offset`/`limit`) + 425 Too-Early semantics. |
| DELETE | `/batch/{job_id}` | Cleanup endpoint with idempotency notes. |

## (2) Discrepancies between `docs/api/rest-api.md` and the code

The PR implements **what the code does**; the markdown should be updated separately. Notable mismatches found:

- **`/ready` checks**: docs claim `{disk_space, memory, models_loaded}`; code returns `{device_probe, iqa_detectors, schema, configuration}`. Implemented as code returns it.
- **`/ready` device payload**: docs show `{type, name, memory_available_gb}`; code returns `{has_local_gpu, gpu_name, cpu_count, modal_available}`. Implemented as code returns it.
- **`/version` pipeline_version**: docs say `"0.1.0"`; code returns `"1.0.0"` (hard-coded). Documented `"1.0.0"`.
- **`/version` model keys**: docs claim `{iqa_student, iqa_teacher, layout_lite}`; code returns `{teacher_model, student_model, layout_model}`. Documented as code returns.
- **`/process` supported file types**: docs include `.bmp`; code's `SUPPORTED_EXTENSIONS` does not (it has `.webp` instead). Documented as code accepts.
- **`/process` `dpi_threshold`**: docs list it as a request option, but the route signature has only `prefer_gpu`, `enable_corrections`, `enable_teacher` (the field exists on the `ProcessingOptions` model but is not exposed by the route). Did not introduce a new parameter; documented only what's currently accepted.
- **`POST /process` parameters**: docs show `-F` (multipart form fields) for the options; code uses FastAPI `Query` params, so they are passed in the URL query string, not the form body. Reflected in the Postman collection.
- **`/batch/{job_id}/status` 404 shape**: docs show `{"error": "not_found", "message": …}`; code raises `HTTPException`, so the actual body is `{"detail": "Job <id> not found"}`. Newman assertions cover only status code 200/404 for resilience.
- **`DELETE /batch/{job_id}` response**: docs show `{"message": "Job deleted successfully", "job_id": "…"}`; code returns `{"message": "Job <id> deleted"}` (single key). Documented and tested as code returns.
- **`POST /batch` `estimated_completion`**: docs include a populated example; code always returns `null` for this field today. Example updated to reflect reality.
- **`GET /batch/{job_id}/result` 425 status**: docs do not mention the 425 case; code returns it when the job is still running. Documented and asserted.
- **Public root**: docs only mention `GET /`; the actual handler returns a JSON nav map (kept hidden from the schema with `include_in_schema=False`, so it does not appear in `openapi.json`).

## (3) Generated artifacts

- `docs/api/openapi.json` — written by `scripts/export_openapi.py`. ✅ Created.
- `docs/api/postman-collection.json` — Postman Collection v2.1, three folders (`Health`, `Detection / Process`, `Correction / Batch`), 9 requests with `{{baseUrl}}` / `{{apiKey}}` / `{{sampleImagePath}}` / `{{jobId}}` variables and status + JSON-body assertions on every request. ✅ Created.
- `.github/workflows/postman-api-tests.yml` — checkout → `uv sync --extra dev --extra api` → install Newman → generate a 64×64 PNG fixture + non-image text fixture → start `uvicorn` → poll `/health` for up to 60 s → `newman run` with JUnit reporter → upload `newman-report.xml` + `uvicorn.log` artifacts → kill the server. Required env vars and secrets are documented in the file header.

## Test plan

- [x] `uv run python scripts/export_openapi.py` writes `docs/api/openapi.json` (8 paths, 13 status codes documented across endpoints).
- [x] FastAPI app boots locally with no ML model files present (lifespan falls back gracefully).
- [x] Local `newman run docs/api/postman-collection.json` → **18 / 18 assertions pass**, 9 / 9 requests OK.
- [x] `uv run ruff check` clean on every file touched in this PR (the one remaining warning, `ASYNC240` in `health.py`, is pre-existing and outside the scope of this change).
- [ ] CI: `Postman API Tests` workflow green on this PR.

https://claude.ai/code/session_01Cm5GBZ1rswMTGqbEFgHwfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cm5GBZ1rswMTGqbEFgHwfN)_