### PR TITLE
chore(renovate): switch to pep621 manager (uv-managed projects)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,7 @@
         "pep621"
       ],
       "matchDepTypes": [
-        "dependencies"
+        "project.dependencies"
       ],
       "groupName": "Python dependencies",
       "automerge": false,
@@ -43,7 +43,8 @@
         "pep621"
       ],
       "matchDepTypes": [
-        "devDependencies"
+        "dependency-groups",
+        "tool.uv.dev-dependencies"
       ],
       "groupName": "Python dev dependencies",
       "automerge": false,

--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,7 @@
     {
       "description": "Group Python dependencies by type",
       "matchManagers": [
-        "poetry"
+        "uv"
       ],
       "matchDepTypes": [
         "dependencies"
@@ -40,7 +40,7 @@
     {
       "description": "Group Python dev dependencies",
       "matchManagers": [
-        "poetry"
+        "uv"
       ],
       "matchDepTypes": [
         "devDependencies"
@@ -193,12 +193,6 @@
   "python": {
     "enabled": true
   },
-  "poetry": {
-    "enabled": true,
-    "fileMatch": [
-      "(^|/)pyproject\\.toml$"
-    ]
-  },
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": [
@@ -233,9 +227,6 @@
   },
   "osvVulnerabilityAlerts": true,
   "transitiveRemediation": true,
-  "postUpdateOptions": [
-    "poetryMassage"
-  ],
   "customManagers": [
     {
       "customType": "regex",
@@ -248,7 +239,7 @@
     }
   ],
   "enabledManagers": [
-    "poetry",
+    "uv",
     "github-actions"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,7 @@
     {
       "description": "Group Python dependencies by type",
       "matchManagers": [
-        "uv"
+        "pep621"
       ],
       "matchDepTypes": [
         "dependencies"
@@ -40,7 +40,7 @@
     {
       "description": "Group Python dev dependencies",
       "matchManagers": [
-        "uv"
+        "pep621"
       ],
       "matchDepTypes": [
         "devDependencies"
@@ -239,7 +239,7 @@
     }
   ],
   "enabledManagers": [
-    "uv",
+    "pep621",
     "github-actions"
   ]
 }


### PR DESCRIPTION
## Summary

This repo manages dependencies with uv (`uv.lock` present), but `renovate.json` declared:

```json
"enabledManagers": ["poetry", "github-actions"]
```

Renovate's `enabledManagers` is replace-not-merge, so the global config does not fill in `uv`. The `poetry` manager tries to parse `pyproject.toml`'s `[tool.poetry.dependencies]` table, but uv projects declare deps under `[project.dependencies]`. Result: Renovate silently parses zero Python deps and produces no PRs.

## Changes

- `enabledManagers`: `poetry` -> `uv`
- `packageRules[*].matchManagers`: `poetry` -> `uv`
- Removed top-level `"poetry": { ... }` block
- Removed `"poetryMassage"` from `postUpdateOptions`

## Test plan

- [ ] Renovate dashboard issue regenerates with Python dependency PRs after merge
- [ ] No regression in GitHub Actions dependency PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched Python dependency management from Poetry to PEP 621, enabled the Python manager, removed Poetry-specific post-update options, and updated grouping rules for runtime and dev dependencies; adjusted enabled managers to reflect the change to PEP 621 for more consistent dependency handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/williaby/image-preprocessing-detector/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->