### PR TITLE
chore(security): pin third-party Actions to commit SHAs

### DIFF
--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Post PR comment
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/security-analysis.yml
+++ b/.github/workflows/security-analysis.yml
@@ -94,7 +94,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install UV
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -234,7 +234,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install UV
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -287,7 +287,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install UV
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"


### PR DESCRIPTION
## Summary

Converts every tag-pinned third-party GitHub Action in this repo to a 40-character commit SHA pin.

## Why

The tj-actions/changed-files compromise (CVE-2025-30066, March 2025) showed that an attacker who controls an Action's repo can rewrite tag pointers to a malicious commit, retroactively poisoning every consumer pinning by tag. SHA pins are immutable.

## Maintenance

- williaby/*: Renovate's `pinDigests: true` rule keeps SHAs current (note: Renovate is currently failing on some williaby repos due to gitPrivateKey errors; see ByronWilliamsCPA/.github#153 for status)

## Test plan

- [ ] CI green on this PR
- [ ] Bot cycle observed post-merge

Tracking: ByronWilliamsCPA/.github#153 (CI-060)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated build pipeline dependencies with pinned versions to ensure reproducible builds and improved stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/williaby/image-preprocessing-detector/pull/191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->