### PR TITLE
chore(gitignore): ignore qlty root symlinks and .worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,11 @@ rag_architecture.png
 # Binary planning documents (use .md equivalents instead)
 *.docx
 siglip2_diqa5000_outputs/
+
+# qlty-materialized tool configs at repo root (absolute-path symlinks regenerated
+# by qlty; canonical copies are tracked under .qlty/configs/)
+/.hadolint.yaml
+/.shellcheckrc
+
+# In-repo git worktrees (created under .worktrees/<branch-slug>)
+/.worktrees/


### PR DESCRIPTION
## Summary

While cleaning up the working tree back to `main`, two untracked entries
turned out to be qlty-materialized **absolute-path symlinks** at the repo root:

- `.hadolint.yaml -> .qlty/configs/.hadolint.yaml`
- `.shellcheckrc -> .qlty/configs/.shellcheckrc`

The canonical configs are already tracked under `.qlty/configs/`, and the root
symlinks hard-code `/home/byron/dev/image_detection/...`, so committing them
would dangle on any other clone or in CI. qlty regenerates them locally on demand.

This PR gitignores those root symlinks plus the in-repo `.worktrees/` directory
so the working tree stays clean.

## Changes

- `.gitignore`: add `/.hadolint.yaml`, `/.shellcheckrc`, `/.worktrees/`

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to ignore additional tool-generated files and directories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/williaby/image-preprocessing-detector/pull/196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->