### PR TITLE
chore(config): make automated reviews advisory, not required to merge

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -30,6 +30,7 @@ This folder contains technical reference materials and operational guides for th
 - [**MIGRATION_GUIDE.md**](MIGRATION_GUIDE.md) - Phase renumbering and migration procedures
 - [**CITATIONS.md**](CITATIONS.md) - Academic citations and references
 - [**REPOSITORY_STRUCTURE.md**](REPOSITORY_STRUCTURE.md) - Repository directory structure
+- [**REVIEW_AND_MERGE_POLICY.md**](REVIEW_AND_MERGE_POLICY.md) - Automated review and branch-merge policy (CodeRabbit advisory, ruleset gates)
 
 ### Testing References
 

--- a/docs/reference/REVIEW_AND_MERGE_POLICY.md
+++ b/docs/reference/REVIEW_AND_MERGE_POLICY.md
@@ -1,0 +1,82 @@
+---
+schema_type: common
+title: "Review and Merge Policy"
+tags:
+  - ci_cd
+  - compliance
+  - reference
+status: published
+owner: docs-team
+purpose: Documents the automated review and branch-merge policy for the default branch.
+---
+
+**Version**: 1.0
+**Last Updated**: 2026-05-28
+
+## Summary
+
+Automated reviewers (CodeRabbit and GitHub Copilot) **run on every pull
+request but do not block merges**. No review approval is required to merge to
+`main`. Merges remain gated only by automated quality checks (signed commits,
+linear history, and required status checks), not by a human or bot approval.
+
+This mirrors the `ByronWilliamsCPA/.claude` and `ByronWilliamsCPA/.github`
+reference repositories, where the default-branch baseline ruleset sets
+`require_code_owner_review: false`.
+
+## Why
+
+This is a solo-maintained repository. Requiring a code-owner review on every PR
+(via `require_code_owner_review: true` combined with a blanket
+[.github/CODEOWNERS](../../.github/CODEOWNERS) entry of `* @williaby`) forced a
+self-approval on every change with no quality benefit. The automated reviewers
+provide the contextual feedback; the CI status checks provide the hard gate.
+
+## Layers
+
+### 1. CodeRabbit (advisory)
+
+Configured in [.coderabbit.yaml](../../.coderabbit.yaml):
+
+- `reviews.auto_review.enabled: true` keeps CodeRabbit reviewing every PR.
+- `reviews.request_changes_workflow: false` keeps it in **advisory** mode, so
+  its review posts as a comment rather than a blocking "Request changes".
+
+### 2. GitHub Copilot review (advisory)
+
+The default-branch ruleset includes the `copilot_code_review` rule, which
+**auto-requests** a Copilot review on each PR. Copilot's review is informational
+and does not gate merge.
+
+### 3. Branch ruleset (the merge gate)
+
+The `williaby-default-branch-baseline` repository ruleset enforces the actual
+merge requirements. Relevant `pull_request` parameters:
+
+| Parameter | Value | Effect |
+| --- | --- | --- |
+| `required_approving_review_count` | `0` | No approvals required |
+| `require_code_owner_review` | `false` | Code-owner approval not required |
+
+Still enforced by the same ruleset (unchanged by this policy):
+
+- `required_signatures` (signed commits)
+- `required_linear_history`
+- `required_status_checks`: Security Gate Validation, Dependency & Standards
+  Validation, Check REUSE Compliance, CI Gate
+
+## Changing this policy
+
+Rulesets are repository settings, not files in this repo, so they are changed
+via the GitHub API rather than a pull request. To re-enable a required
+code-owner review:
+
+```bash
+# Fetch the current ruleset, edit require_code_owner_review, then PUT it back.
+gh api repos/williaby/image-preprocessing-detector/rulesets/16201087 > ruleset.json
+# (edit the pull_request rule's require_code_owner_review to true)
+gh api -X PUT repos/williaby/image-preprocessing-detector/rulesets/16201087 \
+  --input ruleset.json
+```
+
+Keep this document in sync with any ruleset change.


### PR DESCRIPTION
## Summary

Make CodeRabbit and Copilot reviews **run on every PR but not gate merges**, matching the `ByronWilliamsCPA/.claude` and `.github` reference repos.

The `.coderabbit.yaml` was already advisory (`request_changes_workflow: false`, from #195). The actual merge gate was the `williaby-default-branch-baseline` **ruleset** setting `require_code_owner_review: true`, which forced a self-approval on every PR through the blanket `* @williaby` CODEOWNERS entry.

## Changes

- **Ruleset (repo setting, applied via `gh api`)**: `require_code_owner_review` `true` → `false` on `williaby-default-branch-baseline`. Rulesets are not files, so this could not be done in the PR itself.
- **New doc**: `docs/reference/REVIEW_AND_MERGE_POLICY.md` records the policy, the layers (CodeRabbit / Copilot / ruleset), and the `gh api` procedure to revert.
- **Index**: linked the new doc from `docs/reference/README.md`.

## Still enforced (unchanged)

- Signed commits (`required_signatures`)
- Linear history (`required_linear_history`)
- Required status checks: Security Gate Validation, Dependency & Standards Validation, Check REUSE Compliance, CI Gate
- CodeRabbit auto-review + Copilot auto-requested review (both advisory)

## Verification

```
$ gh api repos/williaby/image-preprocessing-detector/rulesets/16201087 \
    -q '.rules[] | select(.type=="pull_request") | .parameters
        | {require_code_owner_review, required_approving_review_count}'
{"require_code_owner_review":false,"required_approving_review_count":0}
```

`pre-commit run` passes on changed files (frontmatter, markdownlint, no-em-dash).

Generated with [Claude Code](https://claude.com/claude-code)