### PR TITLE
chore(deps): add detection-only dependabot.yml (Renovate sole PR-opener)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+# Detection-only: Renovate is the sole PR-opener. open-pull-requests-limit: 0
+# suppresses Dependabot version PRs. Dependabot alerts (a repo setting) remain
+# the multi-ecosystem detection ledger. Refs: standards CI-021 (amended), CI-074.
+updates:
+  - package-ecosystem: "pip"            # Python: pyproject.toml / requirements / uv
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+  - package-ecosystem: "github-actions" # if .github/workflows/ present
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+  - package-ecosystem: "docker"         # if Dockerfile present
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Adds a detection-only `.github/dependabot.yml` so Renovate stays the sole PR-opener while Dependabot's multi-ecosystem detection ledger (alerts) remains active.

## What
- New `.github/dependabot.yml` (version 2) with `open-pull-requests-limit: 0` on every block, suppressing Dependabot version PRs.
- Ecosystem blocks included only where manifests were verified in the clone:
  - `pip` (pyproject.toml + requirements*.txt)
  - `github-actions` (.github/workflows/)
  - `docker` (Dockerfile, Dockerfile.gpu)

## Why
Renovate is the sole PR-opener. Dependabot alerts (a repo setting, not this file) remain the detection ledger. Satisfies amended CI-021 / CI-074.

## Notes
- The repo's existing `.pre-commit-config.yaml` is malformed on the default branch (InvalidConfigError: invalid regex in the `exclude` block). This is pre-existing repo debt unrelated to this change. The added YAML was validated independently as well-formed via `yaml.safe_load`.